### PR TITLE
Implement requiresMainQueueSetup

### DIFF
--- a/ReactNativeHeading.m
+++ b/ReactNativeHeading.m
@@ -36,6 +36,11 @@ RCT_EXPORT_MODULE();
     return self;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_REMAP_METHOD(start, start:(int)headingFilter resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     // Start heading updates.
     if ([CLLocationManager headingAvailable]) {


### PR DESCRIPTION
Fixes the RN warning of `requires main queue setup since it overrides 'init'`