### PR TITLE
Update build.gradle to prevent building application errors

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.+'
+        classpath 'com.android.tools.build:gradle:1.2.0'
     }
 }
 


### PR DESCRIPTION
As mentioned in https://developer.android.com/studio/releases/gradle-plugin,
"Caution: You should not use dynamic dependencies in version numbers, such as 'com.android.tools.build:gradle:2.+'. Using this feature can cause unexpected version updates and difficulty resolving version differences." 
So "com.android.tools.build:gradle:1.2.+" would cause errors when trying to building application with higher versions of gradle ( currently im using 4.2 ).
So changing "com.android.tools.build:gradle:1.2.+" to "com.android.tools.build:gradle:1.2.0" would fix the problem with no breaking issues.